### PR TITLE
[ENH] Complete Basic IOModule

### DIFF
--- a/Ry/Data/metals.csv
+++ b/Ry/Data/metals.csv
@@ -1,0 +1,15 @@
+Metal,Temp Coefficient
+Silver,0.0038
+Copper,0.0039
+Gold,0.0034
+Aluminum,0.0039
+Tungsten,0.0045
+Iron,0.0065
+Platinum,0.0039
+Manganin,0.000002
+Constantan,0.00003
+Mercury,0.0009
+Nichrome,0.0004
+Carbon,0.0005
+Germanium ,0.048
+Silicon,0.07

--- a/Ry/Data/metals.csv
+++ b/Ry/Data/metals.csv
@@ -11,5 +11,5 @@ Constantan,0.00003
 Mercury,0.0009
 Nichrome,0.0004
 Carbon,0.0005
-Germanium ,0.048
+Germanium,0.048
 Silicon,0.07

--- a/Ry/Modules/IOLayer.py
+++ b/Ry/Modules/IOLayer.py
@@ -1,5 +1,6 @@
 import atexit
 import inspect
+import importlib.resources
 import io
 import os
 import pathlib
@@ -403,3 +404,27 @@ def sink(file: os.PathLike[str] | io.TextIOWrapper | None = None) -> None:
                 pass
         atexit.register(close_file)
 
+#################################################
+# Load Builtin Datasets
+##################################################
+
+def data(name: str) -> _pd.DataFrame | _np.ndarray:
+    """Loads a builtin dataset by name.
+
+    Args:
+        name (str): The name of the dataset to load.
+    Returns:
+        pd.DataFrame | np.ndarray: The loaded dataset.
+    Raises:
+        FileNotFoundError: If the dataset does not exist.
+    """
+    try:
+        with importlib.resources.open_binary("Ry.Data", name) as f:
+            if name.endswith(".csv"):
+                return _pd.read_csv(f)
+            elif name.endswith(".npy"):
+                return _np.load(f)
+            else:
+                raise FileNotFoundError(f"Unknown dataset: {name!r}.")
+    except FileNotFoundError:
+        raise FileNotFoundError(f"Unknown dataset: {name!r}.") from None

--- a/Ry/Modules/IOLayer.py
+++ b/Ry/Modules/IOLayer.py
@@ -420,8 +420,15 @@ def data(name: str) -> _pd.DataFrame | _np.ndarray:
     Raises:
         FileNotFoundError: If the dataset does not exist.
     """
+    dir = importlib.resources.files("Ry.Data")
+    if not dir.is_dir():
+        raise FileNotFoundError("Ry.Data package is missing or corrupted.")
     try:
-        with importlib.resources.open_binary("Ry.Data", name) as f:
+        file = next(f for f in dir.iterdir() if f.is_file() and f.name == name)
+    except StopIteration:
+        raise FileNotFoundError(f"Unknown dataset: {name!r}.") from None
+    try:
+        with file.open("rb") as f:
             if name.endswith(".csv"):
                 return _pd.read_csv(f)
             elif name.endswith(".npy"):

--- a/Ry/Modules/IOLayer.py
+++ b/Ry/Modules/IOLayer.py
@@ -45,6 +45,7 @@ SUPPORTED_COMPRESSION_FORMATS: set[_SUPPORTED_COMPRESSION_FORMATS] = {"uncompres
 try:
     from compression import zstd  # pyright: ignore[reportMissingImports]  # Support for zstd compression on 3.14+
     COMPRESSION_FORMAT = "zstd"
+    SUPPORTED_COMPRESSION_FORMATS.add("zstd")
 except ImportError:
     # zstd compression support is optional; if the module is unavailable, fall back to other formats.
     pass

--- a/Ry/Modules/IOLayer.py
+++ b/Ry/Modules/IOLayer.py
@@ -357,13 +357,19 @@ def cat(obj: typing.Any) -> None:
         builtins.print(obj)
     # Pandas DataFrames and Series have their own pretty-printing methods
     elif isinstance(obj, (_pd.DataFrame, _pd.Series)):
+        max_col = _pd.get_option("display.max_columns")
+        max_row = _pd.get_option("display.max_rows")
         _pd.set_option("display.max_columns", None)
         _pd.set_option("display.max_rows", None)
         builtins.print(obj.to_string())
+        _pd.set_option("display.max_columns", max_col)
+        _pd.set_option("display.max_rows", max_row)
     # Numpy ndarrays also have their own pretty-printing methods
     elif isinstance(obj, _np.ndarray):
+        threshold = _np.get_printoptions()["threshold"]
         _np.set_printoptions(threshold=None)
         builtins.print(obj)
+        _np.set_printoptions(threshold=threshold)
     else:
         # use the default string representation for other types
         builtins.print(repr(obj))
@@ -377,13 +383,19 @@ def print(obj: typing.Any) -> None:
     """
     # Pandas DataFrames and Series have their own pretty-printing methods
     if isinstance(obj, (_pd.DataFrame, _pd.Series)):
+        max_col = _pd.get_option("display.max_columns")
+        max_row = _pd.get_option("display.max_rows")
         _pd.set_option("display.max_columns", 20)
         _pd.set_option("display.max_rows", 60)
         builtins.print(obj.to_string())
+        _pd.set_option("display.max_columns", max_col)
+        _pd.set_option("display.max_rows", max_row)
     # Numpy ndarrays also have their own pretty-printing methods
     elif isinstance(obj, _np.ndarray):
+        threshold = _np.get_printoptions()["threshold"]
         _np.set_printoptions(threshold=1000)
         builtins.print(obj)
+        _np.set_printoptions(threshold=threshold)
     else:
         # use pprint for other types
         import pprint

--- a/Ry/Modules/IOLayer.py
+++ b/Ry/Modules/IOLayer.py
@@ -477,14 +477,14 @@ def data(name: str) -> _pd.DataFrame | _np.ndarray:
     if not dir.is_dir():
         raise FileNotFoundError("Ry.Data package is missing or corrupted.")
     try:
-        file = next(f for f in dir.iterdir() if f.is_file() and f.name == name)
+        file = next(f for f in dir.iterdir() if f.is_file() and pathlib.Path(f.name).stem == name)
     except StopIteration:
         raise FileNotFoundError(f"Unknown dataset: {name!r}.") from None
     try:
         with file.open("rb") as f:
-            if name.endswith(".csv"):
+            if file.name.endswith(".csv"):
                 return _pd.read_csv(f)
-            elif name.endswith(".npy"):
+            elif file.name.endswith(".npy"):
                 return _np.load(f)
             else:
                 raise FileNotFoundError(f"Unknown dataset: {name!r}.")

--- a/Ry/Modules/IOLayer.py
+++ b/Ry/Modules/IOLayer.py
@@ -225,17 +225,20 @@ def save(obj: _pd.DataFrame | _pd.Series | _np.ndarray, name: str | None = None)
     
     Args:
         obj (pd.DataFrame | pd.Series | np.ndarray): The object to save.
-        name (str | None): The name to use for the saved file. If None, the variable name will be attempted to inferred.
+        name (str | None): The name to use for the saved file. If None, the variable name will be attempted to be inferred.
     Raises:
         TypeError: If obj is not a pandas DataFrame, Series, or numpy ndarray.
         ValueError: If name is None and the variable name cannot be inferred.
     """
     # Infer the variable name if not provided
     if name is None:
-        lcl = inspect.stack()[2][0].f_locals
-        try:
-            name = next((k for k, v in lcl.items() if v is obj))
-        except StopIteration:
+        for i in {1, 2}:
+            if name is not None:
+                break
+            lcl = inspect.stack()[i][0].f_locals
+            name = next((k for k, v in lcl.items() if v is obj), None)
+            
+        if name is None:
             raise ValueError("Could not infer variable name; please provide a name argument.") from None
     
     # Create the .RyData directory in the current working directory if it doesn't exist

--- a/Ry/Modules/IOLayer.py
+++ b/Ry/Modules/IOLayer.py
@@ -488,5 +488,5 @@ def data(name: str) -> _pd.DataFrame | _np.ndarray:
                 return _np.load(f)
             else:
                 raise FileNotFoundError(f"Unknown dataset: {name!r}.")
-    except FileNotFoundError:
+    except Exception:
         raise FileNotFoundError(f"Unknown dataset: {name!r}.") from None

--- a/Ry/Modules/IOLayer.py
+++ b/Ry/Modules/IOLayer.py
@@ -1,3 +1,5 @@
+"""Python API Layer for Ry I/O Functions."""
+
 import atexit
 import inspect
 import importlib.resources

--- a/Ry/Modules/IOLayer.py
+++ b/Ry/Modules/IOLayer.py
@@ -27,6 +27,8 @@ __all__ = (
     "load",
     "cat",
     "print",
+    "sink",
+    "data",
 )
 
 
@@ -43,9 +45,10 @@ SUPPORTED_COMPRESSION_FORMATS: set[_SUPPORTED_COMPRESSION_FORMATS] = {"uncompres
 try:
     from compression import zstd  # pyright: ignore[reportMissingImports]  # Support for zstd compression on 3.14+
     COMPRESSION_FORMAT = "zstd"
-    SUPPORTED_COMPRESSION_FORMATS.add("zstd")
 except ImportError:
+    # zstd compression support is optional; if the module is unavailable, fall back to other formats.
     pass
+
 try:
     from compression import lzma  # pyright: ignore[reportMissingImports]  # Support for xz compression on 3.14+
     if COMPRESSION_FORMAT is None:
@@ -59,8 +62,8 @@ except ImportError:
         SUPPORTED_COMPRESSION_FORMATS.add("xz")
     except ImportError:
         COMPRESSION_FORMAT = None
-        
-    
+
+
 ################################################
 #  Persistent I/O Functions for DataFrames
 ################################################


### PR DESCRIPTION
Closes #7:
Adds:
- [x] `save()`, `load()` – persist or restore objects
  - I know these are more in depth than originally suggested, but these as written should be better to how people would actually use them and expect them to work
- [x] `cat()` – print concatenated text.
- [x] `print()` – generic object printing.
- [x] `sink()` – redirect console output.
- [x] `data()` – load built-in datasets.
  - [x] Example dataset and temporary dataset directory